### PR TITLE
Add html skeleton to the hearing page

### DIFF
--- a/kuulemma/static/app/app.less
+++ b/kuulemma/static/app/app.less
@@ -4,6 +4,10 @@
 // Variables
 @import './assets/styles/variables';
 
+// Mixins
+@import './assets/styles/mixins';
+
 // Common
-@import './assets/styles/layout';
 @import './assets/styles/footer';
+@import './assets/styles/hearing-show';
+@import './assets/styles/layout';

--- a/kuulemma/static/app/assets/styles/hearing-show.less
+++ b/kuulemma/static/app/assets/styles/hearing-show.less
@@ -1,0 +1,15 @@
+.hearing {
+  .make-row();
+
+  header {
+    .make-column(12, 12);
+  }
+
+  aside {
+    .make-column(2, 2, 2);
+  }
+
+  .content {
+    .make-column(10, 10, 10);
+  }
+}

--- a/kuulemma/static/app/assets/styles/mixins.less
+++ b/kuulemma/static/app/assets/styles/mixins.less
@@ -1,0 +1,6 @@
+.make-column(@large, @medium, @small: 12, @tiny: 12) {
+  .make-lg-column(@large);
+  .make-md-column(@medium);
+  .make-sm-column(@small);
+  .make-xs-column(@tiny);
+}

--- a/kuulemma/templates/hearing/show.html
+++ b/kuulemma/templates/hearing/show.html
@@ -3,7 +3,43 @@
 {% block title %}{{ hearing.title }}{% endblock %}
 
 {% block content %}
-  <h1>{{ hearing.title }}</h1>
-  <p class="lead">{{ hearing.lead }}</p>
-  {{ hearing.body }}
+  <article class="hearing">
+    <header>
+      <ul class="tags"></ul>
+      <h1>{{ hearing.title }}</h1>
+    </header>
+
+    <aside>
+      Sisällys
+    </aside>
+
+    <div class="content">
+      <section class="main-content">
+        <p class="lead">{{ hearing.lead }}</p>
+        {{ hearing.body }}
+      </section>
+
+      <section class="alternatives">
+        <h2>Vaihtoehdot</h2>
+        <article class="alternative">
+          <h3>Vaihtoehto A</h2>
+        </article>
+        <article class="alternative">
+          <h3>Vaihtoehto B</h2>
+        </article>
+      </section>
+
+      <section class="comments">
+        <h2>Kommentit</h2>
+        <p>
+          Kuulemisen tavoitteena on taata kuntalaisille mahdollisuus vaikuttaa käsiteltäviin asioihin koko valmistelutyön ajan. Asioiden kommentointi onnistuu myös ilman tunnuksia. Klikkaa nappia ja jätä ensimmäinen kommenttisi!
+        </p>
+        <h3>Uusimmat kommentit</h3>
+        <article class="comment">
+          <h4>Ensimmäinen kommentti</h4>
+          <p>Lorem ipsum...</p>
+        </article>
+      </section>
+    </div>
+  </article>
 {% endblock %}


### PR DESCRIPTION
Adds basic html skeleton to the hearing page. No styling except the grid. 
